### PR TITLE
fix titanium create task to remove underline character from project id

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,7 @@ module.exports = function(grunt) {
             create: {
                 options: {
                     command: 'create',
-                    id: 'grunttitanium.' + appName.replace('-', ''),
+                    id: 'grunttitanium.' + appName.replace(/-|_/g, ''),
                     name: appName,
                     projectDir: projectDir,
                     workspaceDir: workspaceDir


### PR DESCRIPTION
When the titaniumifier project has a underline in your name, the titanium create task fail.
